### PR TITLE
(chore) add action to build + lint pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run gulp
+      - run: npm run lint


### PR DESCRIPTION
Adds a Github action to run `gulp` and `lint` tasks on pull requests so that we don't accidentally break anything before merging PRs