### PR TITLE
Typo fix in about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@
             <p class="lead">
               Realizing that there are many other ServiceNowians that are also
               awesome like Marty we decided to open it up to everyone. Will you
-              get a piece of acrylic? Probably not. Will you be embalzoned on a
+              get a piece of acrylic? Probably not. Will you be emblazoned on a
               static website until we forget to renew the domain? Most
               definitely.
             </p>


### PR DESCRIPTION
Typo fixed from embalzoned -> emblazoned.
Adding on to issue #14