### PR TITLE
Attempt to fix deployment with composite actions

### DIFF
--- a/.github/build/action.yml
+++ b/.github/build/action.yml
@@ -1,0 +1,10 @@
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+        cache: 'npm'
+    - run: npm ci && npm run gulp && npm run lint
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,19 +3,10 @@ name: CI
 on:
   pull_request:
     branches: [ main ]
-  workflow_call: {}
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          cache: 'npm'
-      - run: npm ci
-      - run: npm run gulp
-      - run: npm run lint
+      - uses: ./.github/build

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -6,20 +6,18 @@ on:
       - main
 
 jobs:
-  build:
-    uses: tallboy/snowgo.at/.github/workflows/ci.yml@main
-
   deploy:
     runs-on: ubuntu-latest
-
     steps:
-    - name: ssh deploy
-      uses: easingthemes/ssh-deploy@v2.2.11
-      env:
-        REMOTE_HOST: ${{ secrets.SSH_HOST }}
-        REMOTE_USER: ${{ secrets.SSH_USERNAME }}
-        REMOTE_PORT: ${{ secrets.SSH_PORT }}
-        SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
-        SOURCE: "dist/"
-        TARGET: "/usr/share/nginx/html/snowgo.at"
-        ARGS: "-avzr --delete"
+      - uses: actions/checkout@v2
+      - uses: ./.github/build
+      - name: ssh deploy
+        uses: easingthemes/ssh-deploy@v2.2.11
+        env:
+          REMOTE_HOST: ${{ secrets.SSH_HOST }}
+          REMOTE_USER: ${{ secrets.SSH_USERNAME }}
+          REMOTE_PORT: ${{ secrets.SSH_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
+          SOURCE: "dist/"
+          TARGET: "/usr/share/nginx/html/snowgo.at"
+          ARGS: "-avzr --delete"


### PR DESCRIPTION
Surprise! #25 broke the deployment workflow, because of [this limitation of re-usable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows#limitations):

> Outputs generated by a called workflow can't be accessed by the caller workflow.

So this flavor uses a [composite action instead of a re-usable workflow](https://github.community/t/reusable-workflows-jobs-outputs/204208), because that's supposed to work better?