### PR TITLE
use native `<dialog>` elements instead of 3rd-party popup lib

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -42,13 +42,6 @@
       type="text/css"
     />
 
-    <!-- Plugin CSS -->
-    <link
-      href="npm:magnific-popup/dist/magnific-popup.css"
-      rel="stylesheet"
-      type="text/css"
-    />
-
     <!-- Custom styles for this template -->
     <link href="scss/snowgoat.scss" rel="stylesheet" />
   </head>
@@ -266,11 +259,11 @@
 
     <!-- goats Modals -->
     <% locals.goats.map(goat => { %>
-    <div class="goats-modal mfp-hide" id="<%= locals.slugify(goat.name) %>">
-      <div class="goats-modal-dialog bg-white">
-        <a class="close-button d-none d-md-block goats-modal-dismiss" href="#">
+    <dialog class="goats-modal" id="<%= locals.slugify(goat.name) %>">
+      <form class="goats-modal-dialog bg-white" method="dialog">
+        <button type="submit" class="close-button btn btn-link d-none d-md-block goats-modal-dismiss">
           <i class="fa fa-3x fa-times"></i>
-        </a>
+        </button>
         <div class="container text-center">
           <div class="row">
             <div class="col-lg-8 mx-auto">
@@ -281,21 +274,18 @@
               <img
                 class="img-fluid mb-5"
                 src="<%= goat.image %>"
-                alt="Aishma Raghu"
+                alt="<%= goat.name %>"
               />
               <p class="mb-5"><%- goat.description %></p>
-              <a
-                class="btn btn-primary btn-lg rounded-pill goats-modal-dismiss"
-                href="#"
-              >
+              <button type="submit" class="btn btn-primary btn-lg rounded-pill goats-modal-dismiss">
                 <i class="fa fa-close"></i>
-                Bye Goat</a
-              >
+                Bye Goat
+              </button>
             </div>
           </div>
         </div>
-      </div>
-    </div>
+      </form>
+    </dialog>
     <% }) %>
 
     <script type="module">

--- a/js/snowgoat.js
+++ b/js/snowgoat.js
@@ -1,7 +1,24 @@
 import $ from 'jquery';
 import * as bootstrap from 'bootstrap';
 import 'jquery.easing';
-import 'magnific-popup';
+
+// trigger modal dialogs; preventing background scroll when open
+document.querySelectorAll(".goats-item").forEach((node) => {
+  node.addEventListener("click", (event) => {
+    event.preventDefault();
+    const dialog = document.querySelector(node.getAttribute("href"));
+    dialog.addEventListener(
+      "close",
+      () => {
+        document.body.classList.remove("scroll-lock");
+      },
+      { once: true },
+    );
+
+    dialog.showModal();
+    document.body.classList.add("scroll-lock");
+  });
+});
 
 // Smooth scrolling using jQuery easing
 $('a.js-scroll-trigger[href*="#"]:not([href="#"])').click(function onClick() {
@@ -61,19 +78,6 @@ const navbarCollapse = () => {
 navbarCollapse();
 // Collapse the navbar when page is scrolled
 $(window).scroll(navbarCollapse);
-
-// Modal popup$(function () {
-$('.goats-item').magnificPopup({
-  type: 'inline',
-  preloader: false,
-  focus: '#username',
-  modal: true,
-});
-
-$(document).on('click', '.goats-modal-dismiss', (e) => {
-  e.preventDefault();
-  $.magnificPopup.close();
-});
 
 // Floating label headings for the contact form
 $(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
                 "bootstrap": "5.1.3",
                 "font-awesome": "4.7.0",
                 "jquery": "3.7.1",
-                "jquery.easing": "^1.4.1",
-                "magnific-popup": "^1.1.0"
+                "jquery.easing": "^1.4.1"
             },
             "devDependencies": {
                 "@parcel/transformer-sass": "^2.12.0",
@@ -5611,15 +5610,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/magnific-popup": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/magnific-popup/-/magnific-popup-1.2.0.tgz",
-            "integrity": "sha512-vkRTVPhQwUgmndX1086k4kMorkzf1XIjBhyL4eIiV8SAjUJQuAdgQEFtMEwbHRFhHOfXe+vcEkRKYLjRAFzMwg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.8.0"
             }
         },
         "node_modules/map-obj": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
         "bootstrap": "5.1.3",
         "font-awesome": "4.7.0",
         "jquery": "3.7.1",
-        "jquery.easing": "^1.4.1",
-        "magnific-popup": "^1.1.0"
+        "jquery.easing": "^1.4.1"
     },
     "devDependencies": {
         "@parcel/transformer-sass": "^2.12.0",

--- a/scss/_bootstrap-overrides.scss
+++ b/scss/_bootstrap-overrides.scss
@@ -1,5 +1,5 @@
 // Bootstrap overrides for this template
-a {
+a, .btn-link {
   color: $primary;
   &:focus,
   &:hover,

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -79,6 +79,12 @@ section {
   line-height: 2rem;
 }
 
+
+// Prevents vertical scroll
+.scroll-lock {
+  overflow-y: hidden;
+}
+
 // Scroll to Top Button
 .scroll-to-top {
   z-index: 1042;

--- a/scss/_goats.scss
+++ b/scss/_goats.scss
@@ -29,16 +29,22 @@
 }
 
 .goats-modal {
+  border: 0;
+  padding: 0;
+  width: 100vw;
+  max-width: 100vw;
+  height: 100vh;
+  max-height: 100vh;
+  background-color: rgb(0 0 0 / 75%);
+
   .goats-modal-dialog {
     padding: 3rem 1rem;
-    min-height: calc(100vh - 2rem);
     margin: 1rem calc(1rem - 8px);
     position: relative;
     z-index: 2;
-    -moz-box-shadow: 0 0 3rem 1rem fade-out(black, .5);
-    -webkit-box-shadow: 0 0 3rem 1rem fade-out(black, .5);
-    box-shadow: 0 0 3rem 1rem fade-out(black, .5);
     .close-button {
+      background: none;
+      border: 0;
       position: absolute;
       top: 2rem;
       right: 2rem;
@@ -55,7 +61,6 @@
   }
   @media(min-width: 768px) {
     .goats-modal-dialog {
-      min-height: 100vh;
       padding: 5rem;
       margin: 3rem calc(3rem - 8px);
       h2 {


### PR DESCRIPTION
Replaces the 3rd-party [magnific-popup](https://github.com/dimsemenov/Magnific-Popup) library with browser-native [`<dialog>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) elements. Unfortunately it's not entirely javascript-free, but it's all pretty straightforward:
- Add `click` listeners to each of the goat image previews. On click, open the dialog and prevent background scroll
- Add `close` listeners to the dialog: when closed, re-enable background scroll

Also tiny bug fix missed in #39: the goat image alt text was hardcoded to Aishma instead of using the goat's name