### PR TITLE
Remove dependency on jQuery

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -258,7 +258,7 @@
     </div>
 
     <!-- Scroll to Top Button (Only visible on small and extra-small screen sizes) -->
-    <div class="scroll-to-top">
+    <div class="scroll-to-top d-lg-none">
       <a
         class="js-scroll-trigger d-block text-center text-white rounded"
         href="#"

--- a/index.ejs
+++ b/index.ejs
@@ -46,14 +46,14 @@
     <link href="scss/snowgoat.scss" rel="stylesheet" />
   </head>
 
-  <body id="page-top">
+  <body>
     <!-- Navigation -->
     <nav
-      class="navbar navbar-expand-lg bg-secondary fixed-top text-uppercase"
+      class="navbar navbar-expand-lg bg-secondary sticky-top text-uppercase"
       id="mainNav"
     >
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="#page-top">Snow Goat</a>
+        <a class="navbar-brand js-scroll-trigger" href="#">Snow Goat</a>
         <button
           class="navbar-toggler navbar-toggler-right text-uppercase bg-primary text-white rounded"
           type="button"
@@ -129,9 +129,19 @@
                 </div>
               </div>
               <picture>
-                <source srcset="<%= goat.image %>?as=avif&width=400" type="image/avif" />
-                <source srcset="<%= goat.image %>?as=webp&width=400" type="image/webp" />
-                <img class="img-fluid cover" src="<%= goat.image %>?as=jpeg&width=400" alt="<%= goat.name %>" />
+                <source
+                  srcset="<%= goat.image %>?as=avif&width=400"
+                  type="image/avif"
+                />
+                <source
+                  srcset="<%= goat.image %>?as=webp&width=400"
+                  type="image/webp"
+                />
+                <img
+                  class="img-fluid cover"
+                  src="<%= goat.image %>?as=jpeg&width=400"
+                  alt="<%= goat.name %>"
+                />
               </picture>
             </a>
           </div>
@@ -248,10 +258,10 @@
     </div>
 
     <!-- Scroll to Top Button (Only visible on small and extra-small screen sizes) -->
-    <div class="scroll-to-top d-lg-none position-fixed">
+    <div class="scroll-to-top">
       <a
         class="js-scroll-trigger d-block text-center text-white rounded"
-        href="#page-top"
+        href="#"
       >
         <i class="fa fa-chevron-up"></i>
       </a>
@@ -277,7 +287,11 @@
               <picture>
                 <source srcset="<%= goat.image %>?as=avif" type="image/avif" />
                 <source srcset="<%= goat.image %>?as=webp" type="image/webp" />
-                <img class="img-fluid mb-5" src="<%= goat.image %>?as=jpeg" alt="<%= goat.name %>" />
+                <img
+                  class="img-fluid mb-5"
+                  src="<%= goat.image %>?as=jpeg"
+                  alt="<%= goat.name %>"
+                />
               </picture>
               <p class="mb-5"><%- goat.description %></p>
               <button
@@ -294,12 +308,6 @@
     </dialog>
     <% }) %>
 
-    <script type="module">
-      // when jQuery is imported as a module, it doesn't define the window
-      // global that is needed for bootstrap to hook in to. Let's do it manually
-      import jQuery from "jquery";
-      window.jQuery = jQuery;
-    </script>
     <script type="module" src="js/snowgoat.js"></script>
   </body>
 </html>

--- a/js/snowgoat.js
+++ b/js/snowgoat.js
@@ -20,30 +20,6 @@ document.querySelectorAll(".goats-item").forEach((node) => {
   });
 });
 
-// Smooth scrolling using jQuery easing
-$('a.js-scroll-trigger[href*="#"]:not([href="#"])').click(function onClick() {
-  if (
-    window.location.pathname.replace(/^\//, "") ===
-      this.pathname.replace(/^\//, "") &&
-    window.location.hostname === this.hostname
-  ) {
-    let target = $(this.hash);
-    target = target.length ? target : $(`[name=${this.hash.slice(1)}]`);
-    if (target.length) {
-      $("html, body").animate(
-        {
-          scrollTop: target.offset().top - 70,
-        },
-        1000,
-        "easeInOutExpo",
-      );
-      return false;
-    }
-  }
-
-  return true;
-});
-
 // Scroll to top button appear
 $(document).scroll(function onScroll() {
   const scrollDistance = $(this).scrollTop();
@@ -77,24 +53,3 @@ const navbarCollapse = () => {
 navbarCollapse();
 // Collapse the navbar when page is scrolled
 $(window).scroll(navbarCollapse);
-
-// Floating label headings for the contact form
-$(() => {
-  $("body")
-    .on(
-      "input propertychange",
-      ".floating-label-form-group",
-      function onInput(e) {
-        $(this).toggleClass(
-          "floating-label-form-group-with-value",
-          !!$(e.target).val(),
-        );
-      },
-    )
-    .on("focus", ".floating-label-form-group", function onFocus() {
-      $(this).addClass("floating-label-form-group-with-focus");
-    })
-    .on("blur", ".floating-label-form-group", function onBlur() {
-      $(this).removeClass("floating-label-form-group-with-focus");
-    });
-});

--- a/js/snowgoat.js
+++ b/js/snowgoat.js
@@ -1,6 +1,4 @@
-import $ from "jquery";
 import * as bootstrap from "bootstrap";
-import "jquery.easing";
 
 // trigger modal dialogs; preventing background scroll when open
 document.querySelectorAll(".goats-item").forEach((node) => {
@@ -20,19 +18,14 @@ document.querySelectorAll(".goats-item").forEach((node) => {
   });
 });
 
-// Scroll to top button appear
-$(document).scroll(function onScroll() {
-  const scrollDistance = $(this).scrollTop();
-  if (scrollDistance > 100) {
-    $(".scroll-to-top").fadeIn();
-  } else {
-    $(".scroll-to-top").fadeOut();
-  }
-});
-
 // Closes responsive menu when a scroll trigger link is clicked
-$(".js-scroll-trigger").click(() => {
-  $(".navbar-collapse").collapse("hide");
+document.querySelectorAll(".js-scroll-trigger").forEach((node) => {
+  node.addEventListener("click", () => {
+    const collapsible = new bootstrap.Collapse(
+      document.querySelector(".navbar-collapse"),
+    );
+    collapsible.collapse();
+  });
 });
 
 // Activate scrollspy to add active class to navbar items on scroll
@@ -41,15 +34,26 @@ new bootstrap.ScrollSpy(document.body, {
   offset: 80,
 });
 
-// Collapse Navbar
-const navbarCollapse = () => {
-  if ($("#mainNav").offset().top > 100) {
-    $("#mainNav").addClass("navbar-shrink");
-  } else {
-    $("#mainNav").removeClass("navbar-shrink");
-  }
-};
-// Collapse now if page is not at top
-navbarCollapse();
-// Collapse the navbar when page is scrolled
-$(window).scroll(navbarCollapse);
+// Scroll to top button appear. Note that this relies on CSS
+// `position: absolute; top: $distance`, where $distance is the length
+// the page needs to scroll before the button should be visible
+new IntersectionObserver((entries) => {
+  const [{ isIntersecting, target }] = entries;
+  const shouldShow = !isIntersecting;
+  target.classList.toggle("enabled", shouldShow);
+}).observe(document.querySelector(".scroll-to-top"));
+
+// Shrink nav when page is not scrolled to top. Note that this relies on CSS
+// `position: sticky; top: -1px` which will trigger this IntersectionObserver
+// as the user scrolls, since it pushes the nav 1px out of the root
+// intersection rect.
+new IntersectionObserver(
+  (entries) => {
+    const [{ intersectionRatio, target }] = entries;
+    const shouldShrink = intersectionRatio < 1;
+    target.classList.toggle("navbar-shrink", shouldShrink);
+  },
+  {
+    threshold: 1,
+  },
+).observe(document.querySelector("#mainNav"));

--- a/js/snowgoat.js
+++ b/js/snowgoat.js
@@ -23,8 +23,11 @@ document.querySelectorAll(".js-scroll-trigger").forEach((node) => {
   node.addEventListener("click", () => {
     const collapsible = new bootstrap.Collapse(
       document.querySelector(".navbar-collapse"),
+      {
+        toggle: false,
+      },
     );
-    collapsible.collapse();
+    collapsible.hide();
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "bootstrap": "5.1.3",
-        "font-awesome": "4.7.0",
-        "jquery": "3.7.1",
-        "jquery.easing": "^1.4.1"
+        "font-awesome": "4.7.0"
       },
       "devDependencies": {
         "@parcel/transformer-sass": "^2.12.0",
@@ -3850,18 +3848,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT"
-    },
-    "node_modules/jquery.easing": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jquery.easing/-/jquery.easing-1.4.1.tgz",
-      "integrity": "sha512-BVpRacWCbNfo/ALWxnLkIY/WRa4Ydg/LtwzIJZvDm7vrhV8Txv+ACi6EGnU11zT19sTc3KEPathWx6CtjWLD1w==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
   "browserslist": "defaults",
   "dependencies": {
     "bootstrap": "5.1.3",
-    "font-awesome": "4.7.0",
-    "jquery": "3.7.1",
-    "jquery.easing": "^1.4.1"
+    "font-awesome": "4.7.0"
   },
   "devDependencies": {
     "@parcel/transformer-sass": "^2.12.0",

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -86,15 +86,28 @@ section {
 
 // Scroll to Top Button
 .scroll-to-top {
-  z-index: 1042;
-  right: 1rem;
-  bottom: 1rem;
-  display: none;
+  position: absolute;
+  top: 100px;
+  opacity: 0;
+  transition: opacity 300ms ease-in;
+
+  &.enabled {
+    opacity: 100;
+  }
+
   a {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
     width: 3.5rem;
     height: 3.5rem;
     background-color: fade-out($gray-900, 0.5);
     line-height: 3.1rem;
+  }
+
+  // never display this button on large screens
+  @media (min-width: 992px) {
+    display: none;
   }
 }
 

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -104,11 +104,6 @@ section {
     background-color: fade-out($gray-900, 0.5);
     line-height: 3.1rem;
   }
-
-  // never display this button on large screens
-  @media (min-width: 992px) {
-    display: none;
-  }
 }
 
 // Custom Links

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -1,6 +1,7 @@
 // Styling for the navbar
 #mainNav {
-  padding-top: 1rem;
+  top: -1px;
+  padding-top: calc(1rem + 1px);
   padding-bottom: 1rem;
   @include heading-font;
   .navbar-brand {


### PR DESCRIPTION
If we only care about modern(ish) browsers, jQuery doesn't really give us much anymore. Bootstrap 5 doesn't need it and we were mostly just using it for simple selectors + adding event listeners. And both of these are simple enough with real DOM APIs now.

Yes I'm still having fun, no judgies 👀 IntersectionObservers are too cool