### PR TITLE
performance: unnecessary optimizations again

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -57,7 +57,7 @@
           aria-label="Toggle navigation"
         >
           Menu
-          <i class="fa fa-bars"></i>
+          <i class="fa fa-bars" aria-hidden="true"></i>
         </button>
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
@@ -83,11 +83,15 @@
     <!-- Header -->
     <header class="masthead bg-primary text-white text-center">
       <div class="container">
-        <img
-          class="img-fluid mb-5 d-block mx-auto"
-          src="img/goats/marty.png"
-          alt="Marty"
-        />
+        <picture>
+          <source srcset="img/goats/marty.png?as=avif" type="image/avif" />
+          <source srcset="img/goats/marty.png?as=webp" type="image/webp" />
+          <img
+            class="img-fluid mb-5 d-block mx-auto"
+            src="img/goats/marty.png?as=jpeg"
+            alt="Marty"
+          />
+        </picture>
         <h1 class="text-uppercase mb-0">Snow Goat</h1>
         <hr class="star-light" />
         <h2 class="font-weight-light mb-0">
@@ -253,6 +257,7 @@
         class="js-scroll-trigger d-block text-center text-white rounded"
         href="#"
       >
+        <span class="sr-only">Scroll to Top</span>
         <i class="fa fa-chevron-up"></i>
       </a>
     </div>

--- a/index.ejs
+++ b/index.ejs
@@ -22,22 +22,15 @@
     />
     <link rel="apple-touch-icon" href="/img/favicons/apple-touch-icon.png" />
 
-    <!-- Bootstrap core CSS -->
-    <link href="npm:bootstrap/dist/css/bootstrap.min.css" rel="stylesheet" />
-
     <!-- Custom fonts for this template -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;1,400;1,700&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+      rel="stylesheet"
+    />
     <link
       href="npm:font-awesome/css/font-awesome.min.css"
-      rel="stylesheet"
-      type="text/css"
-    />
-    <link
-      href="https://fonts.googleapis.com/css?family=Montserrat:400,700"
-      rel="stylesheet"
-      type="text/css"
-    />
-    <link
-      href="https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic"
       rel="stylesheet"
       type="text/css"
     />

--- a/index.ejs
+++ b/index.ejs
@@ -241,11 +241,8 @@
     <div class="copyright py-4 text-center text-white">
       <div class="container">
         <small
-          >Copyright &copy; Snow Goat
-          <script>
-            document.write(new Date().getFullYear());
-          </script>
-          - Made with &hearts; in San Diego</small
+          >Copyright &copy; Snow Goat <%= new Date().getFullYear(); %> - Made
+          with &hearts; in San Diego</small
         >
       </div>
     </div>

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -101,7 +101,7 @@ section {
     right: 1rem;
     width: 3.5rem;
     height: 3.5rem;
-    background-color: fade-out($gray-900, 0.5);
+    background-color: fade-out($gray-600, 0.5);
     line-height: 3.1rem;
   }
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,16 +1,13 @@
 // Variables
 
 $white: #fff !default;
-$gray-100: #f8f9fa !default;
-$gray-200: #e9ecef !default;
-$gray-300: #dee2e6 !default;
-$gray-400: #ced4da !default;
-$gray-500: #adb5bd !default;
-$gray-600: #868e96 !default;
-$gray-700: #495057 !default;
-$gray-800: #343a40 !default;
-$gray-900: #212529 !default;
+$gray-100: #e7e9eb !default;
+$gray-200: #e6e9eb !default;
+$gray-300: #cbcbcb !default;
+$gray-400: #666666 !default;
+$gray-500: #4a4a4a !default;
+$gray-600: #2e2e2e !default;
 $black: #000 !default;
 
-$primary: #087962 !default;
+$primary: #1f8476 !default;
 $secondary: #000000 !default;

--- a/scss/snowgoat.scss
+++ b/scss/snowgoat.scss
@@ -1,3 +1,4 @@
+@import "npm:bootstrap/dist/css/bootstrap.min.css";
 @import "variables.scss";
 @import "mixins.scss";
 @import "global.scss";


### PR DESCRIPTION
Still bored, still having fun making Lighthouse numbers go up. In this round:
- Remove separate CSS/network request for Bootstrap CSS; it's now included in the same CSS bundle as everything else
- Merge Google font requests into a single network call
- More avif/webp/jpeg fallbacks; this time for the Marty header image
- Various accessibility tweaks and other Lighthouse recommendations (like removing `document.write()`)
- Updating the brand colors to the latest that I found [here](https://hi.service-now.com/styles/heisenberg/styleguide/docs/guidelines_-_colors.html), which also fixed some contrast issues

Everything still kinda looks and behaves the same tho

<img width="411" alt="image" src="https://github.com/user-attachments/assets/477e2b8d-ab90-4ef1-ac5c-df218c167535">

I KNOW IT'S NOT ALL 100s, fight me. (But for reals the next step is probably removing bootstrap, as it's the biggest source of unused but included code 👀)